### PR TITLE
More Standardized Field Quotation

### DIFF
--- a/csv2sql.py
+++ b/csv2sql.py
@@ -78,7 +78,7 @@ def output_insert_statement(args, output=sys.stdout):
                 first = False
             else:
                 header_row += ', '
-            header_row += '"' + parse_header(item) + '"'
+            header_row += '`' + parse_header(item) + '`'
         header_row += ') VALUES '
 
         # Set a counter, since there can't be more than 1000 inserts at a time


### PR DESCRIPTION
Simply changes the `"` quotes to `` ` `` in the table field names.  
This seems to be more standardized across DBMS.